### PR TITLE
Add dockerfile for ocp and owners for prow conf

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,0 +1,17 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+WORKDIR /go/src/github.com/metal3-io/metal3-smart-exporter
+ADD . /go/src/github.com/metal3-io/metal3-smart-exporter
+
+RUN go build -o smart_exporter ./smart_exporter.go
+
+FROM rhel7:latest
+
+RUN yum install -y smartmontools && yum clean all
+
+COPY --from=builder /go/src/github.com/metal3-io/metal3-smart-exporter/smart_exporter /bin/smart_exporter
+COPY ./return_smart_info.sh /usr/local/bin/return_smart_info.sh
+RUN chmod +x /usr/local/bin/return_smart_info.sh
+
+EXPOSE 59100
+
+ENTRYPOINT [ "/bin/smart_exporter" ]

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+  - bfournie
+  - derekhiggins
+  - dhellmann
+  - dtantsur
+  - elfosardo
+  - hardys
+  - juliakreger
+  - russellb
+reviewers:
+  - bfournie
+  - derekhiggins
+  - dhellmann
+  - dtantsur
+  - elfosardo
+  - hardys
+  - juliakreger
+  - russellb


### PR DESCRIPTION
This patch adds Dockerfile.ocp to distinguish from the upstream
Dockerfile that has content that we can't use downstream.
Also adds OWNERS for prow and ci configuration.